### PR TITLE
Added dual-provider ASR support (local via vLLM OpenAI-compatible API)

### DIFF
--- a/qwen3_asr_toolkit/audio_tools.py
+++ b/qwen3_asr_toolkit/audio_tools.py
@@ -19,7 +19,6 @@ def load_audio(file_path: str) -> np.ndarray:
         wav_data, _ = librosa.load(file_path, sr=WAV_SAMPLE_RATE, mono=True)
         return wav_data
     except Exception as e:
-        print(e)
         # After librosa fails, use a more powerful ffmpeg as a backup.
         try:
             command = [

--- a/qwen3_asr_toolkit/call_api.py
+++ b/qwen3_asr_toolkit/call_api.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import srt
 import requests
-import dashscope
 import concurrent.futures
 
 from tqdm import tqdm
@@ -19,10 +18,18 @@ def parse_args():
         description="Python toolkit for the Qwen3-ASR API—parallel high‑throughput calls, robust long‑audio transcription, multi‑sample‑rate support."
     )
     parser.add_argument("--input-file", '-i', type=str, required=True, help="Input media file path")
-    parser.add_argument("--context", '-c', type=str, default="", help="Any text context content for Qwen3-ASR-Flash")
+    parser.add_argument("--context", '-c', type=str, default="", help="Optional text context for ASR")
+    parser.add_argument("--provider", choices=["local", "dashscope"], default="local", help="ASR backend to use")
+    parser.add_argument("--api-url", type=str, default="http://localhost:8000/v1/chat/completions", help="Local ASR API endpoint")
+    parser.add_argument("--model", type=str, default=None, help="Model name for the selected API")
+    parser.add_argument("--api-timeout", type=int, default=300, help="API request timeout (seconds)")
+    parser.add_argument("--temperature", type=float, default=0.2, help="Sampling temperature for the local API")
     parser.add_argument("--dashscope-api-key", '-key', type=str, help="DashScope API key")
+    parser.add_argument("--skip-failed", action="store_true", help="Skip failed segments instead of aborting")
+    parser.add_argument("--max-retries", type=int, default=10, help="Max retries per segment")
     parser.add_argument("--num-threads", '-j', type=int, default=4, help="Number of threads to use for parallel calls")
     parser.add_argument("--vad-segment-threshold", '-d', type=int, default=120, help="Segment threshold seconds for VAD")
+    parser.add_argument("--max-segment-seconds", type=int, default=180, help="Hard limit for segment length (seconds)")
     parser.add_argument("--tmp-dir", '-t', type=str, default=os.path.join(os.path.expanduser("~"), "qwen3-asr-cache"), help="Temp directory path")
     parser.add_argument("--save-srt", '-srt', action="store_true", help="Save SRT subtitle file")
     parser.add_argument("--silence", '-s', action="store_true", help="Reduce the output info on the terminal")
@@ -33,9 +40,17 @@ def main():
     args = parse_args()
     input_file = args.input_file
     context = args.context
+    provider = args.provider
+    api_url = args.api_url
+    model = args.model
+    api_timeout = args.api_timeout
+    temperature = args.temperature
+    skip_failed = args.skip_failed
     dashscope_api_key = args.dashscope_api_key
+    max_retries = args.max_retries
     num_threads = args.num_threads
     vad_segment_threshold = args.vad_segment_threshold
+    max_segment_seconds = args.max_segment_seconds
     tmp_dir = args.tmp_dir
     save_srt = args.save_srt
     silence = args.silence
@@ -51,12 +66,20 @@ def main():
     elif not os.path.exists(input_file):
         raise FileNotFoundError(f"Input file \"{input_file}\" does not exist!")
 
-    if dashscope_api_key:
-        dashscope.api_key = dashscope_api_key
-    else:
-        assert "DASHSCOPE_API_KEY" in os.environ, f"Please set DASHSCOPE_API_KEY as an environment variable, or specify it with '-key' argument"
+    if provider == "dashscope":
+        if dashscope_api_key:
+            os.environ["DASHSCOPE_API_KEY"] = dashscope_api_key
+        elif "DASHSCOPE_API_KEY" not in os.environ:
+            raise ValueError("Please set DASHSCOPE_API_KEY or pass --dashscope-api-key.")
 
-    qwen3asr = QwenASR(model="qwen3-asr-flash")
+    qwen3asr = QwenASR(
+        provider=provider,
+        api_url=api_url,
+        model=model,
+        timeout_s=api_timeout,
+        temperature=temperature,
+        max_retries=max_retries,
+    )
 
     wav = load_audio(input_file)
     if not silence:
@@ -67,7 +90,12 @@ def main():
         if not silence:
             print(f"Wav duration is longer than 3 min, initializing Silero VAD model for segmenting...")
         worker_vad_model = load_silero_vad(onnx=True)
-        wav_list = process_vad(wav, worker_vad_model, segment_threshold_s=vad_segment_threshold)
+        wav_list = process_vad(
+            wav,
+            worker_vad_model,
+            segment_threshold_s=vad_segment_threshold,
+            max_segment_threshold_s=max_segment_seconds,
+        )
         if not silence:
             print(f"Segmenting done, total segments: {len(wav_list)}")
     else:
@@ -93,12 +121,22 @@ def main():
             for idx, wav_path in enumerate(wav_path_list)
         }
         if not silence:
-            pbar = tqdm(total=len(future_dict), desc="Calling Qwen3-ASR-Flash API")
+            pbar = tqdm(total=len(future_dict), desc="Calling local ASR API")
         for future in concurrent.futures.as_completed(future_dict):
             idx = future_dict[future]
-            language, recog_text = future.result()
-            results.append((idx, recog_text))
-            languages.append(language)
+            try:
+                language, recog_text = future.result()
+                results.append((idx, recog_text))
+                languages.append(language)
+            except Exception as e:
+                if skip_failed:
+                    results.append((idx, ""))
+                    languages.append("Unknown")
+                    if not silence:
+                        error_name = e.__class__.__name__
+                        print(f"Segment {idx} failed ({error_name}). Skipped.")
+                else:
+                    raise
             if not silence:
                 pbar.update(1)
         if not silence:
@@ -107,7 +145,7 @@ def main():
     # Sort and splice in the original order
     results.sort(key=lambda x: x[0])
     full_text = " ".join(text for _, text in results)
-    language = Counter(languages).most_common(1)[0][0]
+    language = Counter(languages).most_common(1)[0][0] if languages else "Unknown"
 
     if not silence:
         print(f"Detected Language: {language}")
@@ -126,7 +164,7 @@ def main():
         f.write(language + '\n')
         f.write(full_text + '\n')
 
-    print(f"Full transcription of \"{input_file}\" from Qwen3-ASR-Flash API saved to \"{save_file}\"!")
+    print(f"Full transcription of \"{input_file}\" from local ASR API saved to \"{save_file}\"!")
 
     # Save subtitles to local SRT file
     if args.save_srt:
@@ -142,9 +180,10 @@ def main():
                 content=content
             ))
         final_srt_content = srt.compose(subtitles)
-        with open(os.path.splitext(save_file)[0] + ".srt", 'w') as f:
+        srt_path = os.path.splitext(save_file)[0] + ".srt"
+        with open(srt_path, 'w') as f:
             f.write(final_srt_content)
-    print(f"SRT subtitles of \"{input_file}\" from Qwen3-ASR-Flash API saved to \"{save_dir}\"!")
+        print(f"SRT subtitles of \"{input_file}\" from local ASR API saved to \"{srt_path}\"!")
 
 
 if __name__ == '__main__':

--- a/qwen3_asr_toolkit/qwen3asr.py
+++ b/qwen3_asr_toolkit/qwen3asr.py
@@ -1,9 +1,15 @@
 import os
 import time
 import random
-import dashscope
+import re
+import base64
+import mimetypes
+from pathlib import Path
+from typing import Optional
 
 from pydub import AudioSegment
+import requests
+import dashscope
 
 
 MAX_API_RETRY = 10
@@ -26,8 +32,21 @@ language_code_mapping = {
 
 
 class QwenASR:
-    def __init__(self, model: str = "qwen3-asr-flash"):
+    def __init__(
+        self,
+        provider: str,
+        api_url: Optional[str] = None,
+        model: Optional[str] = None,
+        timeout_s: int = 300,
+        temperature: Optional[float] = None,
+        max_retries: int = MAX_API_RETRY,
+    ):
+        self.provider = provider
+        self.api_url = api_url
         self.model = model
+        self.timeout_s = timeout_s
+        self.temperature = temperature
+        self.max_retries = max_retries
 
     def post_text_process(self, text, threshold=20):
         def fix_char_repeats(s, thresh):
@@ -96,7 +115,125 @@ class QwenASR:
         text = fix_char_repeats(text, threshold)
         return fix_pattern_repeats(text, threshold)
 
-    def asr(self, wav_url: str, context: str = ""):
+    def _normalize_content(self, content):
+        if isinstance(content, list):
+            parts = []
+            for item in content:
+                if isinstance(item, dict) and "text" in item:
+                    parts.append(item["text"])
+                else:
+                    parts.append(str(item))
+            return "".join(parts)
+        return str(content)
+
+    def _redact_base64(self, text: str) -> str:
+        if not text:
+            return text
+        return re.sub(r"[A-Za-z0-9+/=]{80,}", "<base64-redacted>", text)
+
+    def _summarize_error(self, error: Exception) -> str:
+        message = f"{error.__class__.__name__}: {error}"
+        message = self._redact_base64(message)
+        if len(message) > 300:
+            message = message[:300] + "...(truncated)"
+        return message
+
+    def _display_audio_ref(self, audio_ref: str) -> str:
+        if not audio_ref:
+            return audio_ref
+        if audio_ref.startswith("data:"):
+            return "<data-url-audio>"
+        return audio_ref
+
+    def _parse_asr_output(self, content):
+        try:
+            from qwen_asr import parse_asr_output  # type: ignore
+            return parse_asr_output(content)
+        except Exception:
+            pass
+
+        content = self._normalize_content(content).strip()
+        lang_match = re.search(r"(?i)language\s*[:=]\s*([A-Za-z-]+)", content)
+        text_match = re.search(r"(?i)text\s*[:=]\s*(.+)", content, re.S)
+        lang_code = lang_match.group(1).lower() if lang_match else None
+        language = language_code_mapping.get(lang_code, "Unknown")
+        text = text_match.group(1).strip() if text_match else content
+        return language, text
+
+    def _to_data_url(self, file_path: str) -> str:
+        mime_type, _ = mimetypes.guess_type(file_path)
+        if not mime_type:
+            mime_type = "application/octet-stream"
+        with open(file_path, "rb") as f:
+            encoded = base64.b64encode(f.read()).decode("ascii")
+        return f"data:{mime_type};base64,{encoded}"
+
+    def _asr_local(self, wav_url: str, context: str = ""):
+        if not wav_url.startswith("http"):
+            assert os.path.exists(wav_url), f"{wav_url} not exists!"
+            file_path = wav_url
+            file_size = os.path.getsize(file_path)
+
+            # file size > 10M
+            if file_size > 10 * 1024 * 1024:
+                # convert to mp3
+                mp3_path = os.path.splitext(file_path)[0] + ".mp3"
+                audio = AudioSegment.from_file(file_path)
+                audio.export(mp3_path, format="mp3")
+                wav_url = mp3_path
+
+            wav_url = self._to_data_url(wav_url)
+
+        # Submit the ASR task
+        response = None
+        display_ref = self._display_audio_ref(wav_url)
+        for _ in range(self.max_retries):
+            try:
+                messages = []
+                if context:
+                    messages.append({
+                        "role": "system",
+                        "content": [{"type": "text", "text": context}],
+                    })
+                messages.append({
+                    "role": "user",
+                    "content": [{
+                        "type": "audio_url",
+                        "audio_url": {"url": wav_url},
+                    }],
+                })
+                payload = {"messages": messages}
+                if self.model:
+                    payload["model"] = self.model
+                if self.temperature is not None:
+                    payload["temperature"] = self.temperature
+
+                response = requests.post(
+                    self.api_url,
+                    headers={"Content-Type": "application/json"},
+                    json=payload,
+                    timeout=self.timeout_s,
+                )
+                response.raise_for_status()
+                response_json = response.json()
+                output = response_json["choices"][0]["message"]["content"]
+                language, recog_text = self._parse_asr_output(output)
+                return language, self.post_text_process(recog_text)
+            except Exception as e:
+                try:
+                    status_code = getattr(response, "status_code", "unknown")
+                    reason = getattr(response, "reason", "")
+                    error_summary = self._summarize_error(e)
+                    print(f"Retry {_ + 1}...  {display_ref}\nHTTP {status_code} {reason}\n{error_summary}")
+                except Exception:
+                    error_summary = self._summarize_error(e)
+                    print(f"Retry {_ + 1}...  {display_ref}\n{error_summary}")
+            time.sleep(random.uniform(*API_RETRY_SLEEP))
+        raise Exception(f"{wav_url} task failed!\n{response}")
+
+    def _asr_dashscope(self, wav_url: str, context: str = ""):
+        if not self.model:
+            raise ValueError("DashScope requires a model name.")
         if not wav_url.startswith("http"):
             assert os.path.exists(wav_url), f"{wav_url} not exists!"
             file_path = wav_url
@@ -112,8 +249,8 @@ class QwenASR:
 
             wav_url = f"file://{wav_url}"
 
-        # Submit the ASR task
-        for _ in range(MAX_API_RETRY):
+        response = None
+        for _ in range(self.max_retries):
             try:
                 messages = [
                     {
@@ -158,16 +295,21 @@ class QwenASR:
             except Exception as e:
                 try:
                     print(f"Retry {_ + 1}...  {wav_url}\n{response}")
-                    if response.code == "DataInspectionFailed":
-                        print(f"DataInspectionFailed! Invalid input audio \"{wav_url}\"")
-                        break
-                except Exception as e:
-                    print(f"Retry {_ + 1}...  {wav_url}\n{e}")
+                except Exception:
+                    error_summary = self._summarize_error(e)
+                    print(f"Retry {_ + 1}...  {error_summary}")
             time.sleep(random.uniform(*API_RETRY_SLEEP))
         raise Exception(f"{wav_url} task failed!\n{response}")
 
+    def asr(self, wav_url: str, context: str = ""):
+        if self.provider == "local":
+            return self._asr_local(wav_url, context)
+        if self.provider == "dashscope":
+            return self._asr_dashscope(wav_url, context)
+        raise ValueError(f"Unknown provider: {self.provider}")
+
 
 if __name__ == "__main__":
-    qwen_asr = QwenASR(model="qwen3-asr-flash")
+    qwen_asr = QwenASR(provider="local", api_url="http://localhost:8000/v1/chat/completions", model=None)
     asr_text = qwen_asr.asr(wav_url="/path/to/your/wav_file.wav")
     print(asr_text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-dashscope
 librosa
 pydub
 silero_vad
@@ -7,5 +6,5 @@ tqdm
 setuptools
 wheel
 requests
-urllib
 srt
+dashscope


### PR DESCRIPTION
Summary  

- Added dual-provider ASR support (local via vLLM OpenAI-compatible API and dashscope via
    DashScope SDK), controlled by --provider.
  - Introduced local API configuration flags: --api-url, --model, --api-timeout, --temperature,
    --max-retries, --max-segment-seconds, and --skip-failed for resilient long-audio runs.
  - Switched local audio uploads to Base64 data: URLs and hardened logging to avoid base64 output
    pollution.
  - Restored dashscope dependency and DashScope API key handling.

  Key Files

  - qwen3_asr_toolkit/qwen3asr.py
  - qwen3_asr_toolkit/call_api.py
  - requirements.txt
  - qwen3_asr_toolkit/audio_tools.py

Tests

python3 -m qwen3_asr_toolkit.call_api -i /home/fuchsia/228.m4a    --provider local  --api-url http://localhost:8000/v1/chat/completions     --model "Qwen/Qwen3-ASR-1.7B"     --api-timeout 60     --max-retries 1     --skip-failed     -j 2     -d 60     --max-segment-seconds 150
/mnt/qwen3-asr/Qwen3-ASR-Toolkit/qwen3_asr_toolkit/audio_tools.py:19: UserWarning: PySoundFile failed. Trying audioread instead.
  wav_data, _ = librosa.load(file_path, sr=WAV_SAMPLE_RATE, mono=True)
/mnt/qwen3-asr/lib/python3.11/site-packages/librosa/core/audio.py:184: FutureWarning: librosa.core.audio.__audioread_load
        Deprecated as of librosa version 0.10.0.
        It will be removed in librosa version 1.0.
  y, sr_native = __audioread_load(path, offset, duration, dtype)
Loaded wav duration: 5802.94s
Wav duration is longer than 3 min, initializing Silero VAD model for segmenting...
Segmenting done, total segments: 96
Calling local ASR API:   0%|                                              | 0/96 [00:00<?, ?it/s]ERROR 03-02 12:10:51 [fa_utils.py:82] Cannot use FA version 2 is not supported due to FA2 is only supported on devices with compute capability >= 8
Calling local ASR API:  82%|██████████████████████████████▍      | 79/96 [02:00<00:43,  2.55s/it]
